### PR TITLE
Fix BlindGeneratorBlindSum test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.14.x
+
+script:
+  - if [ -n "$(gofmt -l .)" ]; then echo "Go code is not formatted"; exit 1; fi
+  - go test -count=1 -race ./... -v

--- a/pedersen.go
+++ b/pedersen.go
@@ -11,7 +11,6 @@ import "C"
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"unsafe"
 )
 
@@ -253,15 +252,12 @@ func BlindGeneratorBlindSum(
 	for i := 0; i < vbl; i++ {
 		C.setBytesArray(gbls, cBuf(generatorblind[i]), C.int(i))
 		if i != fbl {
-			fmt.Println(hex.EncodeToString(blindingfactor[i]))
 			C.setBytesArray(fbls, cBuf(blindingfactor[i]), C.int(i))
 		} else {
 			out := make([]byte, 32)
-			fmt.Println(hex.EncodeToString(out))
 			C.setBytesArray(fbls, cBuf(out), C.int(i))
 		}
 	}
-	fmt.Println(" ")
 	defer C.freeBytesArray(gbls)
 	defer C.freeBytesArray(fbls)
 
@@ -280,7 +276,6 @@ func BlindGeneratorBlindSum(
 	for i := 0; i < vbl; i++ {
 		b := C.getBytesArray(fbls, C.int(i))
 		copy(results[i][:], C.GoBytes(unsafe.Pointer(b), 32))
-		fmt.Println(hex.EncodeToString(results[i][:]))
 	}
 	blindout = results[fbl]
 	return

--- a/pedersen_test.go
+++ b/pedersen_test.go
@@ -97,40 +97,44 @@ func TestPedersenBlindSum(t *testing.T) {
 	}
 }
 
-// func TestPedersenBlindGeneratorBlindSum(t *testing.T) {
-// 	file, err := ioutil.ReadFile("testdata/pedersen.json")
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	var tests map[string]interface{}
-// 	json.Unmarshal(file, &tests)
-// 	vectors := tests["blindGeneratorBlindSum"].([]interface{})
+func TestPedersenBlindGeneratorBlindSum(t *testing.T) {
+	file, err := ioutil.ReadFile("testdata/pedersen.json")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	ctx, _ := ContextCreate(ContextNone)
-// 	defer ContextDestroy(ctx)
+	type testVectorType struct {
+		NumInputs       int      `json:"nInputs"`
+		Values          []uint64 `json:"values"`
+		BlindGenerators []string `json:"blindGenerators"`
+		BlindFactors    []string `json:"blindFactors"`
+		Expected        string   `json:"expected"`
+	}
+	type testType struct {
+		Vectors []testVectorType `json:"blindGeneratorBlindSum"`
+	}
 
-// 	for _, testVector := range vectors {
-// 		v := testVector.(map[string]interface{})
+	var test testType
+	json.Unmarshal(file, &test)
 
-// 		nInputs := int(v["nInputs"].(float64))
-// 		values := []uint64{}
-// 		for _, val := range v["values"].([]interface{}) {
-// 			values = append(values, uint64(val.(float64)))
-// 		}
-// 		blindGenerators := [][]byte{}
-// 		for _, bg := range v["blindGenerators"].([]interface{}) {
-// 			blindGen, _ := hex.DecodeString(bg.(string))
-// 			blindGenerators = append(blindGenerators, blindGen)
-// 		}
-// 		blindFactors := [][]byte{}
-// 		for _, bf := range v["blindFactors"].([]interface{}) {
-// 			blindFct, _ := hex.DecodeString(bf.(string))
-// 			blindFactors = append(blindFactors, blindFct)
-// 		}
+	ctx, _ := ContextCreate(ContextNone)
+	defer ContextDestroy(ctx)
 
-// 		res, err := BlindGeneratorBlindSum(ctx, values, blindGenerators, blindFactors, nInputs)
-// 		assert.NoError(t, err)
-// 		assert.NotNil(t, res)
-// 		assert.Equal(t, v["expected"].(string), hex.EncodeToString(res[:]))
-// 	}
-// }
+	for _, v := range test.Vectors {
+		blindGenerators := [][]byte{}
+		for _, bg := range v.BlindGenerators {
+			blindGen, _ := hex.DecodeString(bg)
+			blindGenerators = append(blindGenerators, blindGen)
+		}
+		blindFactors := [][]byte{}
+		for _, bf := range v.BlindFactors {
+			blindFct, _ := hex.DecodeString(bf)
+			blindFactors = append(blindFactors, blindFct)
+		}
+
+		res, err := BlindGeneratorBlindSum(ctx, v.Values, blindGenerators, blindFactors, v.NumInputs)
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, v.Expected, hex.EncodeToString(res[:]))
+	}
+}

--- a/testdata/pedersen.json
+++ b/testdata/pedersen.json
@@ -199,6 +199,60 @@
         "4ca016bb7f7a15d8c0e1825fb20b76f59750555caf61da77573c028cd3ef62e7"
       ],
       "expected": "e1a140ae971b82910bec2d98a712f757a27d079ce87f1c55a2a0c36f5af27922"
+    },
+    {
+      "nInputs": 0,
+      "values": [1402118166],
+      "blindFactors": [],
+      "blindGenerators": [
+        "2a4573f14ccfb1175c4a1fbcb541ef124cabbab9dce98a783fa50b300ed2d5dd"
+      ],
+      "expected": "9a0c1464053983bf75679461de15546afc7ab51e30301cfce50960829fee4565"
+    },
+    {
+      "nInputs": 0,
+      "values": [3638801394],
+      "blindFactors": [],
+      "blindGenerators": [
+        "56e33a1674c46b1951bb01131a2adfa3165ca7841fcb0b2e540e389766bfb5cd"
+      ],
+      "expected": "87261e97f306cc30e9743fef0312e5ed3107b4c635e9601bc7f0c832f9268689"
+    },
+    {
+      "nInputs": 0,
+      "values": [2211154800],
+      "blindFactors": [],
+      "blindGenerators": [
+        "2c114e642f7336e6e4c99f67143710f8e8d0e790f05adb2175fe19afd7d0200f"
+      ],
+      "expected": "e523b8f2fe9e044f4828159350596a4000fbcf12dfabfcd800ded564abf8c748"
+    },
+    {
+      "nInputs": 0,
+      "values": [2438659112],
+      "blindFactors": [],
+      "blindGenerators": [
+        "906bf458c1023e3af9c18a3284983615cc3ed7d7f529bff7a274a650d25d3ba2"
+      ],
+      "expected": "fe14541a5a31cb9d42dbd96fae6c19695309c3431fde5289f8113ddcf9aeb34c"
+    },
+    {
+      "nInputs": 0,
+      "values": [633090570],
+      "blindFactors": [],
+      "blindGenerators": [
+        "78d892719df56ff76c6ea36f1e8e1eef9a96dd02ba6ca599f4cf6084b7338ab6"
+      ],
+      "expected": "03ab9d48e82bae4912bceed99c77c6ecd4c1cd4f8f960512684e042d991d36f9"
+    },
+    {
+      "nInputs": 0,
+      "values": [405385747],
+      "blindFactors": [],
+      "blindGenerators": [
+        "c3446130478fc5e882712eba6eb17769b413a214689ba2e4f337366bb300cb16"
+      ],
+      "expected": "dee847143a412489a8df899443913284213c1f5aa2a4bde73d4de528e16fb683"
     }
   ]
 }


### PR DESCRIPTION
This fixes the previously commented test for the `BlindGeneratorBlindSum` binding.

Before this, the byte slice returned by this method was not matching the expected one.
After investigating, the problem was actually in the conversion of number values from the json to the `uint64` go built-in type.

By using the generic `interface{}` for converting a json into a golang type when `Unmarshal`ing, every number is automatically converted into a `float64`, and this was causing loss of information when then casting to `uint64`.

The fix for this is to create the custom types `testType` and `testVectorType` that reflect the json structure. In particular, the `testVectorType` contains a `Values` field, among the others, that is declared `[]uint64` so no information is lost in the conversion.  

This closes [#57](https://github.com/vulpemventures/go-elements/issues/57).