### PR TITLE
Fix for go version >= 1.15

### DIFF
--- a/secp256k1.go
+++ b/secp256k1.go
@@ -43,9 +43,8 @@ func init() {
 }
 
 func newContext() *Context {
-	return &Context{
-		ctx: &C.secp256k1_context{},
-	}
+	var ctx *C.secp256k1_context
+	return &Context{ctx}
 }
 
 func cBuf(goSlice []byte) *C.uchar {


### PR DESCRIPTION
This adds fix of CType_struct var declaration. The way it was done before this PR causes error if using go with version >= 1.15.3.