### PR TITLE
update RangeProofVerify

### DIFF
--- a/rangeproof.go
+++ b/rangeproof.go
@@ -134,7 +134,7 @@ func RangeProofInfo(
 //       	 	 gen: additional generator 'h'
 // 	 Out:  	 min_value: pointer to a unsigned int64 which will be updated with the minimum value that commit could have. (cannot be NULL)
 //       	 	 max_value: pointer to a unsigned int64 which will be updated with the maximum value that commit could have. (cannot be NULL)
-func RangeProofVerify(context *Context, proof []byte, commit *Commitment, extraCommit []byte, generator *Generator) bool {
+func RangeProofVerify(context *Context, proof []byte, commit *Commitment, extraCommit []byte, generator *Generator) (bool, int, int) {
 	var cExtraCmt *C.uchar
 	cExtraCmtLen := 0
 	if extraCommit != nil && len(extraCommit) > 0 {
@@ -156,10 +156,10 @@ func RangeProofVerify(context *Context, proof []byte, commit *Commitment, extraC
 		C.size_t(cExtraCmtLen),
 		generator.gen,
 	) {
-		return false
+		return false, 0, 0
 	}
 
-	return true
+	return true, minValue, maxValue
 }
 
 // RangeProofRewind verifies a range proof and rewind the proof to recover information sent by its author.

--- a/rangeproof_test.go
+++ b/rangeproof_test.go
@@ -97,11 +97,8 @@ func TestRangeProofVerify(t *testing.T) {
 		generator, err := GeneratorFromString(v["generator"].(string))
 		assert.NoError(t, err)
 
-		assert.Equal(
-			t,
-			v["expected"].(bool),
-			RangeProofVerify(ctx, proof, commit, extraCommit, generator),
-		)
+		valid, _, _ := RangeProofVerify(ctx, proof, commit, extraCommit, generator)
+		assert.Equal(t, v["expected"].(bool), valid)
 	}
 }
 


### PR DESCRIPTION
This updates RangeProofVerify so that it is returning min and max values.
This is to be used in VerifyBlindValueProof in [here](https://github.com/ElementsProject/elements/blob/7d83cc0089345a0646834986c56e58543fd5ee07/src/blindpsbt.cpp#L193)

@tiero @altafan please review.