### PR TITLE
fix: hide secp api to avoid collissions

### DIFF
--- a/secp256k1.go
+++ b/secp256k1.go
@@ -1,6 +1,8 @@
 package secp256k1
 
 /*
+#define SECP256K1_API __attribute__ ((visibility ("hidden")))
+
 #define USE_BASIC_CONFIG 1
 #include "./secp256k1-zkp/src/basic-config.h"
 


### PR DESCRIPTION
closes: #16 